### PR TITLE
fix socketException

### DIFF
--- a/Response.cs
+++ b/Response.cs
@@ -248,8 +248,8 @@ namespace HTTP
                     }
 
                     int _b;
-                    while( (_b = inputStream.ReadByte()) != -1
-                             && ( contentLength == 0 || output.Length < contentLength ) ) {
+                    while( ( contentLength == 0 || output.Length < contentLength )
+                    	      && (_b = inputStream.ReadByte()) != -1 ) {
                         output.WriteByte((byte)_b);
                     }
 


### PR DESCRIPTION
Unhandled Exception, aborting request.System.IO.IOException: Read failure ---> System.Net.Sockets.SocketException: Connection reset by peer
  at System.Net.Sockets.Socket.Receive (System.Byte[] buffer, Int32 offset, Int32 size, SocketFlags flags) [0x00000] in <filename unknown>:0 
  at System.Net.Sockets.NetworkStream.Read (System.Byte[] buffer, Int32 offset, Int32 size) [0x00000] in <filename unknown>:0 
  --- End of inner exception stack trace ---
  at System.Net.Sockets.NetworkStream.Read (System.Byte[] buffer, Int32 offset, Int32 size) [0x00000] in <filename unknown>:0 
  at System.IO.Stream.ReadByte () [0x00007] in /Users/builduser/buildslave/monoAndRuntimeClassLibs/build/mcs/class/corlib/System.IO/Stream.cs:168 
  at HTTP.Response.ReadFromStream (System.IO.Stream inputStream) [0x0030d] in Scritps/http/Response.cs:217 
  at HTTP.Request.GetResponse (System.Object unused) [0x00142] in Scritps/http/Request.cs:166
