### PR TITLE
Fixed User-Agent when using UnityHTTP in a thread

### DIFF
--- a/src/Request.cs
+++ b/src/Request.cs
@@ -270,7 +270,11 @@ namespace HTTP
             }
 
             if ( GetHeader( "User-Agent" ) == "" ) {
-                SetHeader( "User-Agent", "UnityWeb/1.0 (Unity " + Application.unityVersion + "; " + SystemInfo.operatingSystem + ")" );
+                try {
+                    SetHeader( "User-Agent", "UnityWeb/1.0 (Unity " + Application.unityVersion + "; " + SystemInfo.operatingSystem + ")" );
+                } catch (Exception) {
+                    SetHeader( "User-Agent", "UnityWeb/1.0" );
+                }
             }
 
             if ( GetHeader( "Connection" ) == "" ) {


### PR DESCRIPTION
It would be better to retrieve `Application.unityVersion` and `SystemInfo.operatingSystem` from the main thread (or to ask Unity to authorize access to these properties) but here is a quick fix.
