### PR TITLE
ResponseCallbackDispatcher should be marked with DonDestroyOnLoad()

### DIFF
--- a/src/ResponseCallbackDispatcher.cs
+++ b/src/ResponseCallbackDispatcher.cs
@@ -33,6 +33,7 @@ namespace HTTP
                 }
 
                 singletonGameObject = new GameObject();
+                GameObject.DontDestroyOnLoad(singletonGameObject);
                 singleton = singletonGameObject.AddComponent< ResponseCallbackDispatcher >();
                 singletonGameObject.name = "HTTPResponseCallbackDispatcher";
             }


### PR DESCRIPTION
This patch allows ResponseCallbackDispatcher to survive when a new level
is loaded in.