### PR TITLE
StreamedWWWForm for memory efficient files upload

### DIFF
--- a/src/FormDataStream.cs
+++ b/src/FormDataStream.cs
@@ -1,0 +1,158 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Collections.Generic;
+namespace HTTP {
+
+    public class FormPart {
+        string fieldName;
+        string mimeType;
+        byte[] header;
+        Stream contents;
+        int position = 0;
+
+        public FormPart(string fieldName, string mimeType, string boundary, Stream contents, string fileName=null){
+            string filenameheader = "";
+            if (fileName != null){
+                filenameheader = "; filename=\"" + fileName +"\"";
+            }
+            header =  Encoding.ASCII.GetBytes(
+                "\r\n--" + boundary + "\r\n" +
+                "Content-Type: " + mimeType + "\r\n" +
+                "Content-disposition: form-data; name=\"" + fieldName + "\"" + filenameheader + "\r\n\r\n"
+            );
+            this.contents = contents;
+        }
+        public long Length {
+            get {
+                return header.Length + contents.Length;
+            }
+        }
+        public int Read(byte[] buffer, int offset, int size){
+            int writed = 0;
+            int bytesToWrite;
+            if (position < header.Length){
+                bytesToWrite =  (int)(header.Length - position) > size ? size : (int)(header.Length - position); 
+                Array.Copy (
+                    header,     // from header
+                    position,   // started from position
+                    buffer,     // to buffer
+                    offset,     // started with offset
+                    bytesToWrite
+               );
+               writed += bytesToWrite;
+               position += bytesToWrite;
+            }
+            if (writed >= size){
+                return writed;
+            }
+            bytesToWrite = contents.Read(buffer, writed + offset, size - writed);
+            writed += bytesToWrite;
+            position += bytesToWrite;
+            return writed;
+        }
+    }
+    
+    public class FormDataStream: Stream {
+        long position = 0;
+        List<FormPart> parts = new List<FormPart>();
+        bool dirty = false;
+        byte[] footer;
+        string boundary;
+
+        public FormDataStream(string boundary){
+            this.boundary = boundary;
+            footer = Encoding.ASCII.GetBytes("\r\n--" + boundary + "--\r\n");
+        }
+
+        public override bool CanRead { get { return true; } }
+        public override bool CanSeek { get { return false; } }
+        public override bool CanTimeout { get { return false; } }
+        public override bool CanWrite { get { return false; } }
+        public override int ReadTimeout { get { return 0; } set { } }
+        public override int WriteTimeout { get { return 0; } set { } }
+        public override long Position {
+            get {
+                return position;
+            }
+            set {
+                throw new NotImplementedException("FormDataStream is non-seekable stream");
+            }
+        }
+        public override long Length {
+            get {
+                if (parts.Count == 0){
+                    return 0;
+                }
+                dirty = true;
+                long len = 0;
+                foreach (var part in parts){
+                    len += part.Length;
+                }
+                return len + footer.Length;
+            }
+        }
+
+        public override void Flush(){
+            throw new NotImplementedException("FormDataStream is readonly stream");
+        }
+
+        public override int Read(byte[] buffer, int offset, int count){
+            dirty = true;
+            int writed = 0;
+            int bytesToWrite = 0;
+
+            // write parts
+            long partsSize = 0;
+            foreach (var part in parts){
+                partsSize += part.Length;
+                if (position > partsSize){
+                    continue;
+                }
+                bytesToWrite = part.Read(buffer, writed + offset, count - writed);
+                writed += bytesToWrite;
+                position += bytesToWrite;
+                if (writed >= count){
+                    return count;
+                }
+            }
+
+
+            // write footer
+            bytesToWrite =  count - writed > footer.Length?  footer.Length : count - writed;
+            Array.Copy (footer, 0, buffer, writed + offset, bytesToWrite);
+            position += bytesToWrite;
+            writed += bytesToWrite;
+            return writed;
+        }
+
+        public override long Seek(long amount, SeekOrigin origin){
+            throw new NotImplementedException("FormDataStream is non-seekable stream");
+        }
+        
+        public override void SetLength (long len){
+            throw new NotImplementedException("FormDataStream is readonly stream");
+        }
+        
+        public override void Write(byte[] source, int offset, int count){
+            throw new NotImplementedException("FormDataStream is readonly stream");
+        }
+
+        public void AddPart(string fieldName, string mimeType, Stream contents, string fileName=null){
+            if (dirty){
+                throw new InvalidOperationException("You can't change form data, form already readed");
+            }
+            parts.Add(new FormPart(fieldName, mimeType, boundary, contents, fileName));
+        }
+
+        public void AddPart(FormPart part){
+            if (dirty){
+                throw new InvalidOperationException("You can't change form data, form already readed");
+            }
+            parts.Add(part);
+        }
+    }
+
+}
+
+

--- a/src/Request.cs
+++ b/src/Request.cs
@@ -208,11 +208,17 @@ namespace HTTP
                 }
 
             } catch (Exception e) {
+#if !UNITY_EDITOR
                 Console.WriteLine ("Unhandled Exception, aborting request.");
                 Console.WriteLine (e);
+#else
+                Debug.LogError("Unhandled Exception, aborting request.");
+                Debug.LogException(e);
+#endif
                 exception = e;
                 response = null;
             }
+
             state = RequestState.Done;
             isDone = true;
             responseTime = curcall.ElapsedMilliseconds;
@@ -341,6 +347,10 @@ namespace HTTP
 
             stream.Write( EOL );
 
+            if (byteStream == null){
+                return;
+            }
+
             long numBytesToRead = byteStream.Length;
             byte[] buffer = new byte[bufferSize];
             while (numBytesToRead > 0){
@@ -348,6 +358,7 @@ namespace HTTP
                 stream.Write(buffer, 0, readed);
                 numBytesToRead -= readed;
             }
+            byteStream.Close();
         }
 
         private static string[] sizes = { "B", "KB", "MB", "GB" };

--- a/src/Request.cs
+++ b/src/Request.cs
@@ -223,6 +223,11 @@ namespace HTTP
             isDone = true;
             responseTime = curcall.ElapsedMilliseconds;
 
+            if ( byteStream != null )
+            {
+                byteStream.Close();
+            }
+
             if ( completedCallback != null )
             {
                 if (synchronous) {
@@ -358,7 +363,6 @@ namespace HTTP
                 stream.Write(buffer, 0, readed);
                 numBytesToRead -= readed;
             }
-            byteStream.Close();
         }
 
         private static string[] sizes = { "B", "KB", "MB", "GB" };

--- a/src/StreamedWWWForm.cs
+++ b/src/StreamedWWWForm.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Collections;
+
+namespace HTTP
+{
+    public class StreamedWWWForm {
+        string boundary;
+        public FormDataStream stream;
+
+        public Hashtable headers {
+            get {
+                return new Hashtable {
+                    { "Content-Type", "multipart/form-data; boundary=\"" + boundary + "\""}
+                };
+            }
+        }
+
+        public StreamedWWWForm(){
+            byte[] bytes = new byte[40];
+            var random = new Random();
+            for (int i=0; i<40; i++){
+                bytes[i] = (byte)(48 + random.Next(62));
+                if (bytes[i] > 57){
+                    bytes[i] += 7;
+                }
+                if (bytes[i] > 90){
+                    bytes[i] += 6;
+                }
+            }
+            boundary = Encoding.ASCII.GetString(bytes);
+            stream = new FormDataStream(boundary);
+        }
+        
+        public void AddField(string fieldName, string fieldValue){
+            var contentStream = new MemoryStream(Encoding.UTF8.GetBytes(fieldValue));
+            stream.AddPart(fieldName, "text/plain; charset=\"utf-8\"", contentStream);
+
+        }
+        public void AddBinaryData(string fieldName, byte[] contents=null, string mimeType = null){
+            var contentStream = new MemoryStream(contents);
+            if (mimeType == null){
+                mimeType = "application/octet-stream";
+            }
+            stream.AddPart(fieldName, mimeType, contentStream, fieldName + ".dat");
+        }
+        public void AddBinaryData(string fieldName, Stream contents=null, string mimeType = null){
+            if (mimeType == null){
+                mimeType = "application/octet-stream";
+            }
+            stream.AddPart(fieldName, mimeType, contents, fieldName + ".dat");
+        }
+        public void AddFile(string fieldName, string path, string mimeType=null){
+            if (mimeType == null){
+                mimeType = "application/octet-stream";
+            }
+            var contents = new FileInfo(path).Open(FileMode.Open);
+            stream.AddPart(fieldName, mimeType, contents, fieldName + ".dat");
+        }
+    }
+}


### PR DESCRIPTION
With StreamedWWWForm you can upload large files without loading them into memory.

```c#
var form = new HTTP.StreamedWWWForm();
form.AddField("name", "big_one.bundle");
form.AddFile("data", "bundles/big_one.bundle");
var request = new HTTP.Request("POST", "http://127.0.0.1:8888/upload", form);
request.synchronous = true;
request.Send();
HTTP.Response response = request.response;
if (response.status == 200){
    Debug.Log("Bundle " + name + " uploaded in " + (request.responseTime/1000f).ToString("F") + " seconds" );
} else {
    Debug.LogError("Error uploading bundle to server: [" + response.status + "] " + response.Text);
}
```
