### PR TITLE
Support for both version of WWWForm.headers

### DIFF
--- a/src/FormDataStream.cs
+++ b/src/FormDataStream.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 namespace HTTP {
 
     public class FormPart {
-        string fieldName;
-        string mimeType;
         byte[] header;
         Stream contents;
         int position = 0;
@@ -50,6 +48,11 @@ namespace HTTP {
             writed += bytesToWrite;
             position += bytesToWrite;
             return writed;
+        }
+
+        public void Dispose(){
+            header = null;
+            contents.Close();
         }
     }
     
@@ -150,6 +153,13 @@ namespace HTTP {
                 throw new InvalidOperationException("You can't change form data, form already readed");
             }
             parts.Add(part);
+        }
+        
+        public override void Close(){
+            foreach (var part in parts){
+                part.Dispose();
+            }
+            base.Close();
         }
     }
 

--- a/src/Request.cs
+++ b/src/Request.cs
@@ -89,10 +89,17 @@ namespace HTTP
             this.method = method;
             this.uri = new Uri (uri);
             this.byteStream = new MemoryStream(form.data);
+#if UNITY_5
+            foreach ( var entry in form.headers )
+            {
+                this.AddHeader( entry.Key, entry.Value );
+            }
+#else
             foreach ( DictionaryEntry entry in form.headers )
             {
                 this.AddHeader( (string)entry.Key, (string)entry.Value );
             }
+#endif
 
         }
 


### PR DESCRIPTION
WWWForm.headers changed in Unity5 from HashTable to Dict<str, str>.
This should support both versions and close #48 and #50.
I tested it on Unity 4.6.7 and 5.1.1

There is also some cleanups. 