### PR TITLE
Increased verbosity on SSL authentication exceptions

### DIFF
--- a/src/Request.cs
+++ b/src/Request.cs
@@ -184,7 +184,13 @@ namespace HTTP
                                 var ssl = ostream as SslStream;
                                 ssl.AuthenticateAsClient (uri.Host);
                             } catch (Exception e) {
-                                Debug.LogError ("Exception: " + e.Message);
+#if !UNITY_EDITOR
+                                Console.WriteLine ("SSL authentication failed.");
+                                Console.WriteLine (e);
+#else
+                                Debug.LogError ("SSL authentication failed.");
+                                Debug.LogException(e);
+#endif
                                 return;
                             }
                         }


### PR DESCRIPTION
Currently we will only see an "Exception: The authentication or decryption has failed." message, like in #58. With the new change it is more verbose, giving the user a correct hint on what went wrong like

`CryptographicException: Unsupported hash algorithm: 1.2.840.113549.1.1.13`

Also the code currently assumed Unity without the otherwise used if directive.