### PR TITLE
Don't read body in HEAD requests

### DIFF
--- a/src/Response.cs
+++ b/src/Response.cs
@@ -210,7 +210,7 @@ namespace UnityHTTP
                         AddHeader( parts[0], parts[1] );
                     }
                     
-                } else if (request.method != "head") {
+                } else if (request.method.ToUpper() != "HEAD") {
                     // Read Body
                     int contentLength = 0;
 

--- a/src/Response.cs
+++ b/src/Response.cs
@@ -210,7 +210,7 @@ namespace UnityHTTP
                         AddHeader( parts[0], parts[1] );
                     }
                     
-                } else {
+                } else if (request.method != "head") {
                     // Read Body
                     int contentLength = 0;
 


### PR DESCRIPTION
The Response class tries to read the body and compare the content length of the body with the content length in the header.

There is no body in HEAD requests so of course the body length and header value don't match, which throws an exception.

This PR skips reading the response body if the request method is `head`.