### PR TITLE
Ability to change logging behavior

### DIFF
--- a/src/Logger.cs
+++ b/src/Logger.cs
@@ -22,7 +22,7 @@ namespace UnityHTTP
         }
         public void LogException(Exception e)
         {
-            UnityEngine.Debug.LogException(msg);
+            UnityEngine.Debug.LogException(e);
         }
         public void LogWarning(string msg)
         {
@@ -42,7 +42,7 @@ namespace UnityHTTP
         }
         public void LogException(Exception e)
         {
-            Console.WriteLine(msg);
+            Console.WriteLine(e);
         }
         public void LogWarning(string msg)
         {

--- a/src/Logger.cs
+++ b/src/Logger.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace UnityHTTP
+{
+    public interface ILogger
+    {
+        void Log(string msg);
+        void LogError(string msg);
+        void LogException(Exception e);
+        void LogWarning(string msg);
+    }
+#if UNITY_EDITOR
+    public class UnityLogger : ILogger
+    {
+        public void Log(string msg)
+        {
+            UnityEngine.Debug.Log(msg);
+        }
+        public void LogError(string msg)
+        {
+            UnityEngine.Debug.LogError(msg);
+        }
+        public void LogException(Exception e)
+        {
+            UnityEngine.Debug.LogException(msg);
+        }
+        public void LogWarning(string msg)
+        {
+            UnityEngine.Debug.LogWarning(msg);
+        }
+    }
+#endif
+    public class ConsoleLogger : ILogger
+    {
+        public void Log(string msg)
+        {
+            Console.WriteLine(msg);
+        }
+        public void LogError(string msg)
+        {
+            Console.WriteLine(msg);
+        }
+        public void LogException(Exception e)
+        {
+            Console.WriteLine(msg);
+        }
+        public void LogWarning(string msg)
+        {
+            Console.WriteLine(msg);
+        }
+    }
+}

--- a/src/Logger.cs
+++ b/src/Logger.cs
@@ -49,4 +49,23 @@ namespace UnityHTTP
             Console.WriteLine(msg);
         }
     }
+	public class DiscardLogger : ILogger
+    {
+        public void Log(string msg)
+        {
+            // discard logs
+        }
+        public void LogError(string msg)
+        {
+            // discard logs
+        }
+        public void LogException(Exception e)
+        {
+            // discard logs
+        }
+        public void LogWarning(string msg)
+        {
+            // discard logs
+        }
+    }
 }

--- a/src/Request.cs
+++ b/src/Request.cs
@@ -31,7 +31,7 @@ namespace UnityHTTP
         public static bool VerboseLogging = false;
         public static string unityVersion = Application.unityVersion;
         public static string operatingSystem = SystemInfo.operatingSystem;
-        public static ILogger logger =
+        public static ILogger Logger =
 #if !UNITY_EDITOR
             new ConsoleLogger()
 #else
@@ -56,7 +56,7 @@ namespace UnityHTTP
         public bool synchronous = false;
         public int bufferSize = 4 * 1024;
         
-        public ILogger logger = Request.logger;
+        public ILogger logger = Request.Logger;
 
         public Action< UnityHTTP.Request > completedCallback = null;
 
@@ -339,9 +339,9 @@ namespace UnityHTTP
         public static bool ValidateServerCertificate (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
 #if !UNITY_EDITOR
-            logger.LogWarning( "NET: SSL Cert: " + sslPolicyErrors.ToString() );
+            Logger.LogWarning( "NET: SSL Cert: " + sslPolicyErrors.ToString() );
 #else
-            logger.LogWarning("SSL Cert Error: " + sslPolicyErrors.ToString ());
+            Logger.LogWarning("SSL Cert Error: " + sslPolicyErrors.ToString ());
 #endif
             return true;
         }

--- a/src/Request.cs
+++ b/src/Request.cs
@@ -55,6 +55,8 @@ namespace UnityHTTP
         public long responseTime = 0; // in milliseconds
         public bool synchronous = false;
         public int bufferSize = 4 * 1024;
+        
+        public ILogger logger = Request.logger;
 
         public Action< UnityHTTP.Request > completedCallback = null;
 


### PR DESCRIPTION
I've been using UnityHTTP for some time now, and have found one feature very helpful: the ability to change logging behavior.

This PR introduces 3 different logging behaviors: `UnityLogger` (prints to Unity console), `ConsoleLogger` (prints to System.Console) and `DiscardLogger` (discards logs without actually printing anything).

The loggers can be set per each request, default logger is stored in `Request.Logger`.

The default behavior wasn't changed, I even left some of the #defines in place to maintain 100% char-to-char backwards compatibility.